### PR TITLE
collapse aside content

### DIFF
--- a/src/content/docs/en/main-works/unified-field-theory/section-0.mdx
+++ b/src/content/docs/en/main-works/unified-field-theory/section-0.mdx
@@ -14,19 +14,41 @@ import Section01 from "~/assets/main-works/unified-field-theory/section-0/1.png"
 This content is not yet supported in your language.
 :::
 
+<details open>
+  <summary class="custom-summary">点击收起注解：写在前面</summary>
+  <Aside title="写在前面">
+    本书中所有被包含在这样的块儿中的文字，均来自网站维护者；不包含在这样的块儿中的文字均来自张祥前。
+
+    本网站上《统一场论》的内容为张祥前本人于 2024年10月13日 亲自发送给 [RainDream](mailto:bzsgbq@163.com) 的版本，可以 [点击此处](https://pan.baidu.com/s/1Fn1A4GZaNUJ8GO89LqJkaw?pwd=grti) 下载原文档。**我们的基本理念是完全保留原著内容**，因此如果您发现本网站上内容与原文档存在出入，欢迎通过本注解右下角的邮箱进行反馈。
+
+    为了帮助读者理解，我们会添加一些重要注解，校对公式，修正细节错误，新增动画、配图等。为了和原著内容进行区分，所有注解都会像这段文字这样，被包含在特殊的样式块儿中。另外，**除新增配图之外的所有注解均默认折叠**，以免破坏读者的阅读体验。
+
+    书中会涉及到一些大学本科《高等数学》和《物理学》相关的知识，可以 [点击此处](https://pan.baidu.com/s/14if0AaMRdByVgxAt5ONaoQ?pwd=bv59) 下载相关教材。书中的一些注解会引用到这些教材上的内容。
+
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
+
+<br />
+
 <Image src={Section01} alt="" class="" style="margin:0 auto;" />
 
 统一场论最早是爱因斯坦提出的，他花了40多年时间，希望把电磁场和引力场统一起来，但没有成功。
 
 人类目前发现了自然界有弱力、电磁场力、万有引力、核力4种不同形式的力，其中电场力和磁场力人类已经统一，核力目前人类对此认识很不完善，弱力在主流科学家看来也被统一在电磁场力中。
 
-<Aside title="注解">
-  这里的 "核力" 就是强力, 又称强相互作用, 是作用于强子之间的力，是已知四种基本作用力中最强的，也是作用距离第二短的（大约在10-15 m 范围内）。(来自 [维基百科](https://zh.wikipedia.org/wiki/%E5%BC%BA%E7%9B%B8%E4%BA%92%E4%BD%9C%E7%94%A8))
+<details>
+  <summary class="custom-summary">点击展开注解: 关于“核力”</summary>
+  <Aside title="注解">
+    这里的“核力”就是强力, 又称强相互作用, 是作用于强子之间的力，是已知四种基本作用力中最强的，也是作用距离第二短的（大约在10-15 m 范围内）。(来自 [维基百科](https://zh.wikipedia.org/wiki/%E5%BC%BA%E7%9B%B8%E4%BA%92%E4%BD%9C%E7%94%A8))
 
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 本文认为电场力和磁场力不是同一种力，弱力是电磁场力和核力的合力，不是基本力。本文论述的电场力、磁场力、万有引力、核力的统一，简单的讲，就是把电场力、磁场力、万有引力、核力写在一个数学公式，以及用数学公式写出电场、磁场、万有引力场【简称引力场】、核力场之间的关系。
 

--- a/src/content/docs/en/main-works/unified-field-theory/section-13.mdx
+++ b/src/content/docs/en/main-works/unified-field-theory/section-13.mdx
@@ -16,13 +16,16 @@ This content is not yet supported in your language.
 
 相对论认为时间、位移、电场、磁场、力、质量等很多物理概念是相对的。对于相对运动的不同观测者来测量，可能有不同的数值，这“相对”两个字延伸一下，其是相对于观测者而言。
 
-<Aside title="注解">
-因为上面这些概念，相对于不同观测者有不同数值，所以恰恰说明这些物理量都不是客观存在的，而是观察者描述出来的东西。
+<details>
+  <summary class="custom-summary">点击展开注解：深入理解相对性</summary>
+  <Aside title="注解">
+    因为上面这些物理量，相对于不同观测者有不同数值，所以恰恰说明这些物理量（如时间、质量等）都不是客观存在的，而是观察者描述出来的东西。
 
-<div style="text-align: right;">
-_由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-</div>
-</Aside>
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 由于时间、位移、速度、力、质量、能量······这些物理概念来自于物体【相对于我们观测者】的运动或者物体周围空间本身的运动。
 

--- a/src/content/docs/en/main-works/unified-field-theory/section-14.mdx
+++ b/src/content/docs/en/main-works/unified-field-theory/section-14.mdx
@@ -31,13 +31,16 @@ This content is not yet supported in your language.
 
 两个右手螺旋式空间【正面对我们观察者都是逆时针旋转】相互碰撞，旋转相互接触地方空间会减少，表现为相互吸引，而左手螺旋空间和右手螺旋空间相遇，会相互排斥。
 
-<Aside title="注解">
-  为什么旋转相互的接触地方空间会减少？这是因为在接触处空间运动方向相反，相互抵消，如下图所示：
+<details>
+  <summary class="custom-summary">点击展开注解: 为什么旋转相互的接触地方空间会减少？</summary>
+  <Aside title="注解">
+    为什么旋转相互的接触地方空间会减少？这是因为在接触处空间运动方向相反，相互抵消，如下图所示：
 
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 <Image src={Section141} alt="" class=""  style="margin:0 auto;"/>
 

--- a/src/content/docs/en/main-works/unified-field-theory/section-15.mdx
+++ b/src/content/docs/en/main-works/unified-field-theory/section-15.mdx
@@ -57,19 +57,22 @@ This content is not yet supported in your language.
 
 二维曲面空间中发生的信息，可以保存在一维线性空间中，严格的证明，可以用场论中的斯托克斯定理。
 
-<Aside title="注解">
-  简单来说，
-  “高斯定理”表明了三维体积分可以转化为二维面积分，
-  “斯托克斯定理”表明二维面积分可以转化为一维线积分。
+<details>
+  <summary class="custom-summary">点击展开注解：关于“高斯定理”和“斯托克斯定理”</summary>
+  <Aside title="注解">
+    简单来说，
+    “高斯定理”表明了三维体积分可以转化为二维面积分，
+    “斯托克斯定理”表明二维面积分可以转化为一维线积分。
+      
+    对上述两定理更详细准确的描述，可以参考“同济大学《高等数学》（第七版）”中第十一章的第五节和第六节。
     
-  对上述两定理更详细准确的描述，可以参考“同济大学《高等数学》（第七版）”中第十一章的第五节和第六节。
-  
-  <Image src={img_2024_11_14_17_59_04} alt="" class="" style="margin:0 auto; width:80%;"/>
+    <Image src={img_2024_11_14_17_59_04} alt="" class="" style="margin:0 auto; width:80%;"/>
 
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 我们需要注意：
 

--- a/src/content/docs/en/main-works/unified-field-theory/section-19.mdx
+++ b/src/content/docs/en/main-works/unified-field-theory/section-19.mdx
@@ -25,22 +25,27 @@ This content is not yet supported in your language.
 
 下面我们来建立统一场论中的三维圆柱状螺旋时空方程，来替代相对论中四维时空方程。
 
-<Aside title="注解">
-  以下的变量命名不是很规范清晰，但为了尽量不改动原著内容，仍沿用原著的命名方式。
-  
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+<details>
+  <summary class="custom-summary">点击展开注解: 关于本书中变量命名问题的说明</summary>
+  <Aside title="注解">
+    以下的变量命名不是很规范清晰，但为了尽量不改动原著内容，仍沿用原著的命名方式。
+    
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
-<Aside title="新增配图">
-{/* 调整大小为原图50% */}
-  <Image src={img_2024_11_14_19_52_36} alt="" class="" style="margin:0 auto; width:70%;"/>
-  
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+<details open>
+  <summary class="custom-summary">点击收起配图</summary>
+  <Aside title="新增配图">
+    <Image src={img_2024_11_14_19_52_36} alt="" class="" style="margin:0 auto; width:70%;"/>
+    
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 设想在某处空间区域里存在着一个质点 $o$ 点，相对于我们观测者静止，我们以 $o$ 点为原点，建立一个三维笛卡尔直角坐标系 $x,y,z$ 。
 
@@ -59,13 +64,16 @@ $$
 \end{equation}
 $$
 
-<Aside title="注解">
-  "$\vec{r}$ 随着空间位置 $x, y, z$ 和时间 $t$ 变化而变化"这句话容易引发人的困惑, 让人觉得 $\vec{r}$ 是关于 $x, y, z, t$ 这四个变量的函数, 应写成 $\vec{r}=f(x, y, z, t)$; 但是实际上, 统一场论认为时间是观察者周围空间光速运动所给观察者的感觉, 空间本身的位移和时间其实是同一个东西; 所以上面的公式就是想表述出空间位移和时间的对应关系。
-  
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+<details>
+  <summary class="custom-summary">点击展开注解: 关于 $\vec{r}$ 为什么不表示成 $x, y, z, t$ 的四元函数</summary>
+  <Aside title="注解">
+    "$\vec{r}$ 随着空间位置 $x, y, z$ 和时间 $t$ 变化而变化"这句话容易引发人的困惑, 让人觉得 $\vec{r}$ 是关于 $x, y, z, t$ 这四个变量的函数, 应写成 $\vec{r}=f(x, y, z, t)$; 但是实际上, 统一场论认为时间是观察者周围空间光速运动所给观察者的感觉, 空间本身的位移和时间其实是同一个东西; 所以上面的公式就是想表述出空间位移和时间的对应关系。
+    
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 给出了 $\vec{r}(t)$ 和 $(x, y, z)$ 的具体关系，是以上的时空同一化方程：
 
@@ -75,31 +83,37 @@ $$
 \end{equation}
 $$
 
-<Aside type="danger" title="公式修正">
-  这里将原著上述公式中 $x, y, z$ 修正为带有 $\Delta$ 的项。
+<details>
+  <summary class="custom-summary">点击展开公式修正</summary>
+  <Aside type="danger" title="公式修正">
+    这里将原著上述公式中 $x, y, z$ 修正为带有 $\Delta$ 的项。
 
-  修正后公式: (其中 $\Delta x = x - x_0,\ \Delta y = y - y_0,\ \Delta z = z - z_0$)
+    修正后公式: (其中 $\Delta x = x - x_0,\ \Delta y = y - y_0,\ \Delta z = z - z_0$)
 
-  $$
-  \begin{equation}\nonumber
-  \vec{r}(t) = \vec{r_0}+\vec{c}t = (x_0 + \Delta x)\vec{i} + (y_0 + \Delta y)\vec{j} + (z_0 + \Delta z)\vec{k}
-  \end{equation}
-  $$
+    $$
+    \begin{equation}\nonumber
+    \vec{r}(t) = \vec{r_0}+\vec{c}t = (x_0 + \Delta x)\vec{i} + (y_0 + \Delta y)\vec{j} + (z_0 + \Delta z)\vec{k}
+    \end{equation}
+    $$
 
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 这个方程有时候也可以简写为：
 
-<Aside title="注解">
-  这里简写的含义是, 以空间点 $p$ 在初始时刻的位置为原点, 即 $\vec{r_0}=(0, 0, 0)$
-  
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+<details>
+  <summary class="custom-summary">点击展开注解：此处“简写”的含义</summary>
+  <Aside title="注解">
+    这里简写的含义是, 以空间点 $p$ 在初始时刻的位置为原点, 即 $\vec{r_0}=(0, 0, 0)$
+    
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 $$
 \begin{equation}\nonumber
@@ -117,31 +131,37 @@ $$
 
 $r$ 是矢量 $\vec{r}$ 的数量。
 
-<Aside title="新增动画">
-  <VideoPlayer
-    sources={[
-      { src: "/videos/zh-cn/SpaceTimeIsomorphismEquation.mp4", type: "video/mp4" }
-    ]}
-    imageSrc="/gifs/zh-cn/SpaceTimeIsomorphismEquation.gif"
-    alt="Unified Field Theory Model"
-  />
+<details open>
+  <summary class="custom-summary">点击收起动画</summary>
+  <Aside title="新增动画">
+    <VideoPlayer
+      sources={[
+        { src: "/videos/zh-cn/SpaceTimeIsomorphismEquation.mp4", type: "video/mp4" }
+      ]}
+      imageSrc="/gifs/zh-cn/SpaceTimeIsomorphismEquation.gif"
+      alt="Unified Field Theory Model"
+    />
 
-  <div style="text-align: right;">
-    _由 **[uft@obiscr.com](mailto:uft@obiscr.com)** 添加，[在这里报告错误](https://github.com/unified-field-theory-org/animations/issues/new?title=%E5%8F%91%E7%8E%B0%E5%8A%A8%E7%94%BB%E6%B8%B2%E6%9F%93%E9%94%99%E8%AF%AF&labels=animations)_
-  </div>
-</Aside>
+    <div style="text-align: right;">
+      _由 **[uft@obiscr.com](mailto:uft@obiscr.com)** 添加，[在这里报告错误](https://github.com/unified-field-theory-org/animations/issues/new?title=%E5%8F%91%E7%8E%B0%E5%8A%A8%E7%94%BB%E6%B8%B2%E6%9F%93%E9%94%99%E8%AF%AF&labels=animations)_
+    </div>
+  </Aside>
+</details>
 
-<Aside type="caution" title="疑问">
-  如果一个空间点花费时间 $t$ 从 $(x_0,y_0,z_0)$ 运动到 $(x,y,z)$, 并且空间点的运动轨迹为螺旋线, 那么应该是 $(x_0,y_0,z_0)$ 到 $(x,y,z)$ 的弯曲的运动轨迹线的长度等于 $ct$, 而不是 $(x_0,y_0,z_0)$ 到 $(x,y,z)$ 的直线段的长度为 $ct$, 这应该怎么理解呢?
+<details>
+  <summary class="custom-summary">点击展开疑问</summary>
+  <Aside type="caution" title="疑问">
+    如果一个空间点花费时间 $t$ 从 $(x_0,y_0,z_0)$ 运动到 $(x,y,z)$, 并且空间点的运动轨迹为螺旋线, 那么应该是 $(x_0,y_0,z_0)$ 到 $(x,y,z)$ 的弯曲的运动轨迹线的长度等于 $ct$, 而不是 $(x_0,y_0,z_0)$ 到 $(x,y,z)$ 的直线段的长度为 $ct$, 这应该怎么理解呢?
 
-  <Image src={img_2024_11_14_20_17_48} alt="" class="" style="margin:0 auto; width:50%;"/>
+    <Image src={img_2024_11_14_20_17_48} alt="" class="" style="margin:0 auto; width:50%;"/>
 
-  或许这里不能用惯常的 "位移=速度×时间" 来理解空间的运动, 因为统一场论中本身就是用空间运动来定义时间的。
-  
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+    或许这里不能用惯常的 "位移=速度×时间" 来理解空间的运动, 因为统一场论中本身就是用空间运动来定义时间的。
+    
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 以上方程在相对论中也出现过，相对论中被认为是四维时空距离，真实情况是时间的本质就是我们对光速运动的空间的描述。三维空间中任意一维以光速运动，我们就可以认为是时间。
 
@@ -157,15 +177,18 @@ $r$ 是矢量 $\vec{r}$ 的数量。
 
 如果 $p$ 点在 $XOY$ 平面上以原点为圆心，以角速度 $\omega$ 旋转运动，在 $z$ 轴上以匀速度 $h$ 直线运动，$\vec{r}$ 在 $x$、$y$ 平面上投影长度为 $R$，则有:
 
-<Aside title="新增配图">
-  $XOY$ 平面上的投影
+<details open>
+  <summary class="custom-summary">点击收起配图</summary>
+  <Aside title="新增配图">
+    $XOY$ 平面上的投影
 
-  <Image src={img_2024_11_14_20_22_33} alt="" class="" style="margin:0 auto; width:70%;"/>
-  
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+    <Image src={img_2024_11_14_20_22_33} alt="" class="" style="margin:0 auto; width:70%;"/>
+    
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 $$
 \begin{align}
@@ -175,25 +198,27 @@ z =& z_0 + h t \nonumber
 \end{align}
 $$
 
+<details>
+  <summary class="custom-summary">点击展开公式修正</summary>
+  <Aside type="danger" title="公式修正">
+    原著中完整形式的 "三维螺旋时空方程" 是有问题的, 我对它进行了修正
+    修正后公式: (其中 $t'$ 为 $\vec{r_0}=(x_0, y_0, z_0)$ 对应的时刻, $t''$ 为 $\vec{r}=(x, y, z)$ 对应的时刻, $t'' - t' = t$)
 
-<Aside type="danger" title="公式修正">
-  原著中完整形式的 "三维螺旋时空方程" 是有问题的, 我对它进行了修正
-  修正后公式: (其中 $t'$ 为 $\vec{r_0}=(x_0, y_0, z_0)$ 对应的时刻, $t''$ 为 $\vec{r}=(x, y, z)$ 对应的时刻, $t'' - t' = t$)
+    $$
+    \begin{align}
+    x =& x_0 + R(cos(\omega t'') - cos(\omega t')) \nonumber \\
+    y =& y_0 + R(sin(\omega t'') - sin(\omega t')) \nonumber \\
+    z =& z_0 + h t \nonumber
+    \end{align}
+    $$
 
-  $$
-  \begin{align}
-  x =& x_0 + R(cos(\omega t'') - cos(\omega t')) \nonumber \\
-  y =& y_0 + R(sin(\omega t'') - sin(\omega t')) \nonumber \\
-  z =& z_0 + h t \nonumber
-  \end{align}
-  $$
+    可以明显看出, 原著公式的错误在于, 误认为 $cos(A) - cos(B) = cos(A-B)$
 
-  可以明显看出, 原著公式的错误在于, 误认为 $cos(A) - cos(B) = cos(A-B)$
-
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 以上也可以用以下矢量方程表示，
 
@@ -206,23 +231,26 @@ $$
 \end{equation}
 $$
 
-<Aside type="danger" title="公式修正">
-  修正后公式: (其中 $t'$ 为 $\vec{r_0}=(x_0, y_0, z_0)$ 对应的时刻, $t''$ 为 $\vec{r}=(x, y, z)$ 对应的时刻, $t'' - t' = t$)
-  
-  $$
-  \begin{equation} \nonumber
-  \begin{aligned}
-  \vec{r} =& \vec{r_0} + \vec{c}t \\
-  =& \{x_0 + R[cos(\omega t'') - cos(\omega t')]\} \vec{i} + \{y_0 + R[sin(\omega t'') - sin(\omega t')]\} \vec{j} \\
-  & + (z_0+ht)\vec{k}
-  \end{aligned}
-  \end{equation}
-  $$
+<details>
+  <summary class="custom-summary">点击展开公式修正</summary>
+  <Aside type="danger" title="公式修正">
+    修正后公式: (其中 $t'$ 为 $\vec{r_0}=(x_0, y_0, z_0)$ 对应的时刻, $t''$ 为 $\vec{r}=(x, y, z)$ 对应的时刻, $t'' - t' = t$)
+    
+    $$
+    \begin{equation} \nonumber
+    \begin{aligned}
+    \vec{r} =& \vec{r_0} + \vec{c}t \\
+    =& \{x_0 + R[cos(\omega t'') - cos(\omega t')]\} \vec{i} + \{y_0 + R[sin(\omega t'') - sin(\omega t')]\} \vec{j} \\
+    & + (z_0+ht)\vec{k}
+    \end{aligned}
+    \end{equation}
+    $$
 
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 以上可以叫三维螺旋时空方程。
 
@@ -234,15 +262,18 @@ $$
 \end{equation}
 $$
 
-<Aside title="新增配图">
-  上述“简化”的含义为，以 $\vec{r_0}$ 方向为 $x$ 轴方向，并且以旋转圆心为原点，如下图所示：
+<details>
+  <summary class="custom-summary">点击展开注解：此处“简化”的含义</summary>
+  <Aside title="新增配图">
+    上述“简化”的含义为，以 $\vec{r_0}$ 方向为 $x$ 轴方向，并且以旋转圆心为原点，如下图所示：
 
-  <Image src={img_2024_11_14_20_29_20} alt="" class="" style="margin:0 auto; width:60%;"/>
+    <Image src={img_2024_11_14_20_29_20} alt="" class="" style="margin:0 auto; width:60%;"/>
 
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 统一场论认为，宇宙的一切奥妙都是以上方程决定的，大到银河系、星球，小到电子、质子、中子的运动，以及物体为什么有质量、为什么有电荷，一直到人的思维等等······，都与这个方程有关。
 
@@ -261,13 +292,16 @@ $$
 
 上式 $\mathbf{X}$ , $\mathbf{Y}$ 是旋转量，如果 $\mathbf{X} \times \mathbf{Y} = \mathbf{Z}$ 表示右手螺旋关系，则 $\mathbf{Y} \times \mathbf{X} = - \mathbf{Z}$ 则表示左手螺旋关系。
 
-<Aside type="caution" title="疑问">
-  这里应该都是表示右手螺旋关系吧？
-  
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+<details>
+  <summary class="custom-summary">点击展开疑问：应该都是表示右手螺旋关系吧？</summary>
+  <Aside type="caution" title="疑问">
+    这里应该都是表示右手螺旋关系吧？
+    
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 式 $\mathbf{X} \times \mathbf{Y} = \mathbf{Z}$ 和 $\mathbf{Y} \times \mathbf{X} = - \mathbf{Z}$ 反映了空间的旋转运动和直线运动之间的联系。
 

--- a/src/content/docs/en/main-works/unified-field-theory/section-20.mdx
+++ b/src/content/docs/en/main-works/unified-field-theory/section-20.mdx
@@ -38,13 +38,16 @@ $$
 
 就是时空同一化方程。
 
-<Aside title="注解">
-  上述方程中的 $\vec{r}$ 为空间位矢，相当于将时间和空间写到了一个等式里，因此叫做时空同一化方程。其实这个方程其实就是描述了空间运动，并用它来定义了时间。
-  
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+<details>
+  <summary class="custom-summary">点击展开注解：关于上述方程为什么叫“时空同一化方程”的进一步说明</summary>
+  <Aside title="注解">
+    上述方程中的 $\vec{r}$ 为空间位矢，相当于将时间和空间写到了一个等式里，因此叫做时空同一化方程。其实这个方程其实就是描述了空间运动，并用它来定义了时间。
+    
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 原子中的电子生活在小空间范围内，运动速度极快，运动周期极短。而太阳系内，行星在大范围空间里运动，速度小，周期长，这一切的背后都是时空同一性的原因。
 

--- a/src/content/docs/en/main-works/unified-field-theory/section-21.mdx
+++ b/src/content/docs/en/main-works/unified-field-theory/section-21.mdx
@@ -17,14 +17,17 @@ This content is not yet supported in your language.
 
 ## 对洛伦兹变换中光速不变的解释
 
-<Aside title="注解">
-  这一部分其实在推导 $\vec{v}$ (光源运动速度) 与 $\vec{c}$ (矢量光速) 方向相同时的洛伦兹变换公式，并且推导方式就是目前物理学界常用的方式，并不是统一场论提出的。但是统一场论对其中的光速不变进行了更加本质和深刻的解释。
-  
-  另外，下面的变量命名也存在各种细节问题，比如：既把 $x$ 作为一个坐标值, 又把它作为一个坐标轴的名称; 点 $p$ 在正文中用的小写字母，在图片中却用的大写字母；坐标系 $s$ 在正文中用的小写字母，在图片中却用的大写字母；等等。但由于不影响理解, 先不进行校正。
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+<details>
+  <summary class="custom-summary">点击展开注解：本节导读</summary>
+  <Aside title="注解">
+    这一部分其实在推导 $\vec{v}$ (光源运动速度) 与 $\vec{c}$ (矢量光速) 方向相同时的洛伦兹变换公式，并且推导方式就是目前物理学界常用的方式，并不是统一场论提出的。但是统一场论对其中的光速不变进行了更加本质和深刻的解释。
+    
+    另外，下面的变量命名也存在各种细节问题，比如：既把 $x$ 作为一个坐标值, 又把它作为一个坐标轴的名称; 点 $p$ 在正文中用的小写字母，在图片中却用的大写字母；坐标系 $s$ 在正文中用的小写字母，在图片中却用的大写字母；等等。但由于不影响理解, 先不进行校正。
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 设有两个直角惯性坐标系 $s$ 系和 $s'$ 系，任意一事件发生的地点【我们称为考察点 $p$】、时间，在 $s$ 系、$s'$ 系中的时空坐标分别用 $(x, y, z, t)$ 和 $(x', y', z', t')$ 来表示。
 
@@ -95,13 +98,16 @@ $$
 
 由于 $s$ 系相对于 $s'$ 系是匀速直线运动，因而我们应该合理的认为 $x'$ 和 $(x-vt)$ ，$x$ 和 $(x'+vt')$ 之间的关系应该是线性的，满足于简单的正比关系。
 
-<Aside type="caution" title="疑问">
-  上面这句描述看起来很想当然，不严谨，仍需进一步的解释。
-  
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+<details>
+  <summary class="custom-summary">点击展开疑问：关于上述论述的严谨性</summary>
+  <Aside type="caution" title="疑问">
+    上面这句描述看起来很想当然，不严谨，仍需进一步的解释。
+    
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 相对论的相对性原理认为：物理定律在所有的惯性参考系中都是相同或者平权的，不同惯性系的物理方程形式应该是相同的。
 
@@ -242,13 +248,16 @@ $$
 \end{equation}
 $$
 
-<Aside title="注解">
-  上面 "量纲是速率" 的表述不太准确. 明白他想表达的意思即可.
-  
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+<details>
+  <summary class="custom-summary">点击展开注解：关于上述“量纲是速率”的表述</summary>
+  <Aside title="注解">
+    上面“量纲是速率”的表述不太准确. 明白他想表达的意思即可。
+    
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 所以，以上说明了一定会有一个与时间密切相关的特殊速率【我们用 $c$ 来表示】，在相互运动的两个观测者看来，$c$ 的值是相等的。
 
@@ -313,14 +322,16 @@ $$
 
 ## 在空间点运动方向与速度 v 垂直的情况下光速不变的解释
 
-<Aside title="注解">
-  这一部分其实在推导 $\vec{v}$ (光源运动速度) 与 $\vec{c}$ (矢量光速) 方向垂直时的洛伦兹变换公式，并且推导方式就是目前物理学界常用的方式，并不是统一场论提出的。
-  
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
-
+<details>
+  <summary class="custom-summary">点击展开注解：本节导读</summary>
+  <Aside title="注解">
+    这一部分其实在推导 $\vec{v}$ (光源运动速度) 与 $\vec{c}$ (矢量光速) 方向垂直时的洛伦兹变换公式，并且推导方式就是目前物理学界常用的方式，并不是统一场论提出的。
+    
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 可能有人认为光线可以向任意方向跑啊，那空间岂不是也向任意方向跑吗？描述任何运动需有参照物，空间的运动又是参照谁呢？
 
@@ -346,13 +357,16 @@ $$
 
 空间点 $p$ 在零时刻出发运动到 $p$ 点这个事情，在 $s$ 系的观察者看来，$p$ 点在时间 $t$ 内走了 $op$ 这么远的路程。
 
-<Aside title="注解">
-  上面又同时用 $p$ 这个字母表示 "空间点" 和 "空间点在上述运动过程中的结束位置" 了，明白意思就好，这里不影响理解，所以尽量保留原著内容，不进行校正。
-  
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+<details>
+  <summary class="custom-summary">点击展开注解：关于一个字母表示多种含义的问题</summary>
+  <Aside title="注解">
+    上面又同时用 $p$ 这个字母表示 "空间点" 和 "空间点在上述运动过程中的结束位置" 了，明白意思就好，这里不影响理解，所以尽量保留原著内容，不进行校正。
+    
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 $op$ 的路程虽然比 $o'p$ 远，但是，所~~有~~用的时间 $t$ 应该比时间 $t'$ 要长。
 
@@ -616,13 +630,16 @@ c'_z &= \dfrac{c_z\sqrt{1-\dfrac{v^2}{c^2}}}{1-\dfrac{c_x v}{c^2}} \nonumber
 \end{align}
 $$
 
-<Aside title="注解">
-  上述公式是基于目前物理界常用的“完整形式的相对论速度变换公式”，又可称“完整形式的洛伦兹速度变换公式”得到的。具体公式可参考 [此链接](https://www.cnblogs.com/howardzhangdqs/p/rtor.html#612-%E5%AE%8C%E6%95%B4%E7%9A%84%E6%B4%9B%E4%BC%A6%E5%85%B9%E9%80%9F%E5%BA%A6%E5%8F%98%E6%8D%A2%E5%85%AC%E5%BC%8F)。具体推导过程可参考 [此链接](https://query.libretexts.org/%E7%AE%80%E4%BD%93%E4%B8%AD%E6%96%87/%E5%A4%A7%E5%AD%A6%E7%89%A9%E7%90%86%E5%AD%A6_III-%E5%85%89%E5%AD%A6%E4%B8%8E%E7%8E%B0%E4%BB%A3%E7%89%A9%E7%90%86%E5%AD%A6_(OpenSTAX)/05%3A_%E7%9B%B8%E5%AF%B9%E8%AE%BA/5.07%3A_%E7%9B%B8%E5%AF%B9%E8%AE%BA%E9%80%9F%E5%BA%A6%E5%8F%98%E6%8D%A2)（该链接推导的是逆变换，本书这里用的公式是正变换, 它们的推导思想是相同的）。
-  
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+<details>
+  <summary class="custom-summary">点击展开注解：关于上述公式的推导</summary>
+  <Aside title="注解">
+    上述公式是基于目前物理界常用的“完整形式的相对论速度变换公式”，又可称“完整形式的洛伦兹速度变换公式”得到的。具体公式可参考 [此链接](https://www.cnblogs.com/howardzhangdqs/p/rtor.html#612-%E5%AE%8C%E6%95%B4%E7%9A%84%E6%B4%9B%E4%BC%A6%E5%85%B9%E9%80%9F%E5%BA%A6%E5%8F%98%E6%8D%A2%E5%85%AC%E5%BC%8F)。具体推导过程可参考 [此链接](https://query.libretexts.org/%E7%AE%80%E4%BD%93%E4%B8%AD%E6%96%87/%E5%A4%A7%E5%AD%A6%E7%89%A9%E7%90%86%E5%AD%A6_III-%E5%85%89%E5%AD%A6%E4%B8%8E%E7%8E%B0%E4%BB%A3%E7%89%A9%E7%90%86%E5%AD%A6_(OpenSTAX)/05%3A_%E7%9B%B8%E5%AF%B9%E8%AE%BA/5.07%3A_%E7%9B%B8%E5%AF%B9%E8%AE%BA%E9%80%9F%E5%BA%A6%E5%8F%98%E6%8D%A2)（该链接推导的是逆变换，本书这里用的公式是正变换, 它们的推导思想是相同的）。
+    
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 由以上可以导出：
 

--- a/src/content/docs/en/main-works/unified-field-theory/section-22.mdx
+++ b/src/content/docs/en/main-works/unified-field-theory/section-22.mdx
@@ -92,12 +92,15 @@ This content is not yet supported in your language.
 
 场的本质是以圆柱状螺旋式运动的空间，圆柱状螺旋式运动是旋转运动和旋转平面垂直方向直线运动的合成，而散度描述了空间的直线运动部分，旋度描述了空间的旋转运动部分。
 
-<Aside title="注解">
-  上述 "高斯定理", "斯托克斯定理", "散度", "旋度" 等, 可以参考“同济大学《高等数学》（第七版）下册”中第十一章的第五节和第六节进行更深入的了解。
+<details>
+  <summary class="custom-summary">点击展开注解：关于上述“高斯定理”、“斯托克斯定理”、“散度”、“旋度”等概念</summary>
+  <Aside title="注解">
+    上述“高斯定理”、“斯托克斯定理”、“散度”、“旋度”等概念，可以参考“同济大学《高等数学》（第七版）下册”中第十一章的第五节和第六节进行更深入的了解。
 
-  <Image src={img_2024_11_15_10_37_28} alt="" class="" style="margin:0 auto; width:80%;"/>
-  
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+    <Image src={img_2024_11_15_10_37_28} alt="" class="" style="margin:0 auto; width:80%;"/>
+    
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>

--- a/src/content/docs/en/main-works/unified-field-theory/section-23.mdx
+++ b/src/content/docs/en/main-works/unified-field-theory/section-23.mdx
@@ -22,13 +22,16 @@ This content is not yet supported in your language.
 
 $o$ 点在周围产生的引力场 $\vec{A}$ ，表示了穿过包围 $o$ 点的高斯球面 $s$ 上，以光速发散运动的空间位移的条数。
 
-<Aside title="注解">
-  "高斯球面" (Gaussian surface) 是在矢量场分析中的一个重要概念，它是一个假想的封闭曲面。在这里，具体是指围绕质点 $o$ 的一个球形封闭曲面，可以是任意半径。这个球面用于计算通过它的空间位移通量。
-  
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+<details>
+  <summary class="custom-summary">点击展开注解：什么是“高斯球面”？</summary>
+  <Aside title="注解">
+    “高斯球面” (Gaussian surface) 是在矢量场分析中的一个重要概念，它是一个假想的封闭曲面。在这里，具体是指围绕质点 $o$ 的一个球形封闭曲面，可以是任意半径。这个球面用于计算通过它的空间位移通量。
+    
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 
 ## 引力场的定义方程
@@ -43,15 +46,18 @@ $$
 \end{equation}
 $$
 
-<Aside title="注解">
-  此处公式容易引发误解，因为它将 $\vec{r}$ 写成一个关于 $x, y, z, t$ 的四元函数，将时间 $t$ 看作了第四个维度，让人感觉和统一场论的时空同一性背道而驰，反而是降维到了相对论的四维时空观。更符合统一场论基本原理的公式，可以参考本书“十九、螺旋时空波动方程”中如下图所示部分内容。但这里无需纠结这一问题，因为不影响本章内容的理解。
+<details>
+  <summary class="custom-summary">点击展开注解：关于此处将 $\vec{r}$ 写成了一个关于 $x, y, z, t$ 的四元函数</summary>
+  <Aside title="注解">
+    此处公式容易引发误解，因为它将 $\vec{r}$ 写成一个关于 $x, y, z, t$ 的四元函数，将时间 $t$ 看作了第四个维度，让人感觉和统一场论的时空同一性背道而驰，反而是降维到了相对论的四维时空观。更符合统一场论基本原理的公式，可以参考本书“十九、螺旋时空波动方程”中如下图所示部分内容。但这里无需纠结这一问题，因为不影响本章内容的理解。
 
-  <Image src={img_2024_11_15_10_53_02} alt="" class="" style="margin:0 auto; width:80%;"/>
-  
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+    <Image src={img_2024_11_15_10_53_02} alt="" class="" style="margin:0 auto; width:80%;"/>
+    
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 注意，$p$ 点在空间中走过的轨迹是圆柱状螺旋式，我们也可以认为是矢径 $\vec{r}$ 的一个端点 $o$ 不动，另一个端点 $p$ 运动变化，使得 $\vec{r}$ 在空间中划过一条圆柱状螺旋式轨迹。
 
@@ -69,15 +75,18 @@ A = 常数乘以 \dfrac{\Delta{n}}{\Delta{S}}
 \end{equation}
 $$
 
-<Aside title="注解">
-  这里实际上是给出了“引力场强度大小”和“空间位移密度”之间的关系：“引力场强度”的大小，就等于“空间位移密度”。这与目前大学物理教材中, 给出的“电场强度”就等于“电场线密度”，是类似的：(以下内容截取自“马文蔚《物理学》（第六版）上册” p172)
-  
-  <Image src={img_2024_11_15_10_59_13} alt="" class="" style="margin:0 auto; width:80%;"/>
+<details>
+  <summary class="custom-summary">点击展开注解：与“电场强度”的类比</summary>
+  <Aside title="注解">
+    这里实际上是给出了“引力场强度大小”和“空间位移密度”之间的关系：“引力场强度”的大小，就等于“空间位移密度”。这与目前大学物理教材中, 给出的“电场强度”就等于“电场线密度”，是类似的：(以下内容截取自“马文蔚《物理学》（第六版）上册” p172)
+    
+    <Image src={img_2024_11_15_10_59_13} alt="" class="" style="margin:0 auto; width:80%;"/>
 
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 上式给出的引力场定义简单明了，但过于粗糙，不能把引力场矢量性质表现出来，也没有把以矢量光速运动的空间位移 $\vec{r}$ 带进式子中去。
 
@@ -108,23 +117,26 @@ $$
 \end{equation}
 $$
 
-<Aside type="caution" title="疑问">
-  我对上面这段论述有极大的疑惑：“因为只有 $\Delta{n}=1$ 的情况下公式才具有物理意义，所以 $\Delta{n}$ 就直接等于1” 这种说法肯定是有问题的；至少是表述得很不清晰和不严谨的。
+<details>
+  <summary class="custom-summary">点击展开疑问</summary>
+  <Aside type="caution" title="疑问">
+    我对上面这段论述有极大的疑惑：“因为只有 $\Delta{n}=1$ 的情况下公式才具有物理意义，所以 $\Delta{n}$ 就直接等于1” 这种说法肯定是有问题的；至少是表述得很不清晰和不严谨的。
 
-  按照我的理解，应该写为：
+    按照我的理解，应该写为：
 
-  $$
-  \begin{equation}\nonumber
-  \vec{A} = - \dfrac{G\ k\ \Delta{n}\ \vec{r}}{\Delta{S}\ r} = - \dfrac{G\ k\ \vec{r}}{\frac{\Delta{S}}{\Delta{n}}\ r}
-  \end{equation}
-  $$
+    $$
+    \begin{equation}\nonumber
+    \vec{A} = - \dfrac{G\ k\ \Delta{n}\ \vec{r}}{\Delta{S}\ r} = - \dfrac{G\ k\ \vec{r}}{\frac{\Delta{S}}{\Delta{n}}\ r}
+    \end{equation}
+    $$
 
-  我认为原著公式中第三个式子 ($- \frac{G\ k\ \vec{r}}{\Delta{S}\ r}$) 中的 $\Delta{S}$，其实表达的是 "单位条数对应的面积"，和第二个式子 ($- \frac{G\ k\ \Delta{n}\ \vec{r}}{\Delta{S}\ r}$) 中的 $\Delta{S}$ 其实是不同的，但作者用了同一个字母表达它们。而且很乱的一点是，这里明明舍弃了 $\Delta{n}$，但是下面依然频繁出现 $\Delta{n}$。
-  
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+    我认为原著公式中第三个式子 ($- \frac{G\ k\ \vec{r}}{\Delta{S}\ r}$) 中的 $\Delta{S}$，其实表达的是 "单位条数对应的面积"，和第二个式子 ($- \frac{G\ k\ \Delta{n}\ \vec{r}}{\Delta{S}\ r}$) 中的 $\Delta{S}$ 其实是不同的，但作者用了同一个字母表达它们。而且很乱的一点是，这里明明舍弃了 $\Delta{n}$，但是下面依然频繁出现 $\Delta{n}$。
+    
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 上式中为什么用 $\vec{r}$ 的单位矢量 $\dfrac{\vec{r}}{c}$，而不是直接用矢量 $\vec{r}$ ？
 
@@ -138,13 +150,16 @@ $$
 \end{equation}
 $$
 
-<Aside type="danger" title="公式修正">
-  上述公式最后一个式子似乎少乘了一个 $cos \theta$；即最后一个式子应为: $-G\ k\ \Delta n\ cos \theta$
-  
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+<details>
+  <summary class="custom-summary">点击展开公式修正：最后一个式子似乎少乘了一个 $cos \theta$</summary>
+  <Aside type="danger" title="公式修正">
+    上述公式最后一个式子似乎少乘了一个 $cos \theta$；即最后一个式子应为: $-G\ k\ \Delta n\ cos \theta$
+    
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 上式中 $A$ 是引力场 $\vec{A}$ 的数量。
 
@@ -265,13 +280,16 @@ m = \dfrac{k}{\Omega}
 \end{equation}
 $$
 
-<Aside title="注解">
-  注意上式中 $\Omega$ 的含义也会发生变化，变成“单位空间位移对应的立体角”了。原著中经常有类似的地方，用同一个字母表达多个含义，明白其意思就好。
-  
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+<details>
+  <summary class="custom-summary">点击展开注解：关于上式中 $\Omega$ 含义的说明</summary>
+  <Aside title="注解">
+    注意上式中 $\Omega$ 的含义也会发生变化，变成“单位空间位移对应的立体角”了。原著中经常有类似的地方，用同一个字母表达多个含义，明白其意思就好。
+    
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 我们一旦知道了质量的本质，就可以对牛顿力学中的引力场方程 $\vec{A} = -\dfrac{G\ m\ \vec{r}}{r^3}$ 做出解释。
 
@@ -299,18 +317,20 @@ $$
 \end{equation}
 $$
 
-
-<Aside title="注解">
-  这里的 $\vec{\nabla}$ 叫做向量微分算子。
-  
-  对于一般的向量场: $\vec{A}(x, y, z) = P(x, y, z)\vec{i} + Q(x, y, z)\vec{j} + R(x, y, z)\vec{k}$, $(\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z})\vec{i} + (\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x})\vec{j} + (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\vec{k}$ 叫做向量场 $\vec{A}$ 的旋度, 记作 $\overrightarrow{\textup{rot}}\ \vec{A}$. 并且有 $\overrightarrow{\textup{rot}} \vec{A} = \vec{\nabla} \times \vec{A}$ 
-  
-  (摘自“同济大学《高等数学》（第七版）下册” p246)
-  
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+<details>
+  <summary class="custom-summary">点击展开注解：关于“旋度”</summary>
+  <Aside title="注解">
+    这里的 $\vec{\nabla}$ 叫做向量微分算子。
+    
+    对于一般的向量场: $\vec{A}(x, y, z) = P(x, y, z)\vec{i} + Q(x, y, z)\vec{j} + R(x, y, z)\vec{k}$, $(\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z})\vec{i} + (\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x})\vec{j} + (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\vec{k}$ 叫做向量场 $\vec{A}$ 的旋度, 记作 $\overrightarrow{\textup{rot}}\ \vec{A}$. 并且有 $\overrightarrow{\textup{rot}} \vec{A} = \vec{\nabla} \times \vec{A}$ 
+    
+    (摘自“同济大学《高等数学》（第七版）下册” p246)
+    
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 对静止引力场
 
@@ -328,13 +348,16 @@ $$
 \end{equation}
 $$
 
-<Aside title="注解">
-  对于一般的向量场：$\vec{A}(x, y, z) = P(x, y, z)\vec{i} + Q(x, y, z)\vec{j} + R(x, y, z)\vec{k}$，$\frac{\partial P}{\partial x} + \frac{\partial Q}{\partial y} + \frac{\partial R}{\partial z}$ 叫做向量场 $\vec{A}$ 的散度，记作 $\textup{div}\ \vec{A}$。并且有 $\textup{div}\ \vec{A} = \vec{\nabla} \cdot \vec{A} = \frac{\partial P}{\partial x} + \frac{\partial Q}{\partial y} + \frac{\partial R}{\partial z}$ (摘自“同济大学《高等数学》（第七版）下册” p238)
-  
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+<details>
+  <summary class="custom-summary">点击展开注解：关于“散度”</summary>
+  <Aside title="注解">
+    对于一般的向量场：$\vec{A}(x, y, z) = P(x, y, z)\vec{i} + Q(x, y, z)\vec{j} + R(x, y, z)\vec{k}$，$\frac{\partial P}{\partial x} + \frac{\partial Q}{\partial y} + \frac{\partial R}{\partial z}$ 叫做向量场 $\vec{A}$ 的散度，记作 $\textup{div}\ \vec{A}$。并且有 $\textup{div}\ \vec{A} = \vec{\nabla} \cdot \vec{A} = \frac{\partial P}{\partial x} + \frac{\partial Q}{\partial y} + \frac{\partial R}{\partial z}$ (摘自“同济大学《高等数学》（第七版）下册” p238)
+    
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 但在 $r$ 趋近于零【也可以说空间点 $p$ 无限趋近于 $o$ 点】，且 $o$ 点可以看成一个无限小的球体的情况下，式子出现了 $\dfrac{0}{0}$ 的情况，利用狄拉克 $\delta$ 函数，可以得到：
 
@@ -348,13 +371,16 @@ $G$ 是万有引力常数，$u = \dfrac{m}{\Delta x \Delta y \Delta z}$ 是物�
 
 统一场论给出的引力场定义方程的旋度和散度，和牛顿力学给出的引力场的散度、旋度是一致的。
 
-<Aside title="注解">
-  肯定是一致的。因为统一场论给出的引力场定义方程，相比于牛顿力学，只是进一步将质量 $m$ 展开为 $\dfrac{k\ \Delta n}{\Omega}$，而上述推导都假设 $m$ 不变，将其视作常数。
-  
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+<details>
+  <summary class="custom-summary">点击展开注解：为什么是一致的？</summary>
+  <Aside title="注解">
+    肯定是一致的。因为统一场论给出的引力场定义方程，相比于牛顿力学，只是进一步将质量 $m$ 展开为 $\dfrac{k\ \Delta n}{\Omega}$，而上述推导都假设 $m$ 不变，将其视作常数。
+    
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 
 ## 从质量定义方程导出相对论质速关系
@@ -409,13 +435,16 @@ d\Omega = dV
 \end{equation}
 $$
 
-<Aside type="caution" title="疑问">
-  由于 $\Delta V = \dfrac{1}{3}\Delta S\ r$，所以上面的两个公式是否应该分别修正成 $d\Omega = \dfrac{3\ dV}{r^3}$ 和 $d\Omega = 3\ dV$ ？
-  
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+<details>
+  <summary class="custom-summary">点击展开疑问：上式是否应该写为 $d\Omega = 3\ dV$ ？</summary>
+  <Aside type="caution" title="疑问">
+    由于 $\Delta V = \dfrac{1}{3}\Delta S\ r$，所以上面的两个公式是否应该分别修正成 $d\Omega = \dfrac{3\ dV}{r^3}$ 和 $d\Omega = 3\ dV$ ？
+    
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 有了以上的准备知识，我们来考虑以上的 $o$ 点在 $s'$ 系里，静止时候质量
 
@@ -460,13 +489,16 @@ $$
 
 我们只有把 $s$ 系里的时间 $t$ 取一个固定的时刻，$x$ 和 $x'$ 相互比较才有意义，所以，$dt/dx=0$，得出微分式：
 
-<Aside type="caution" title="疑问">
-  上面这句解释并没有说清楚为什么 $dt/dx=0$
-  
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+<details>
+  <summary class="custom-summary">点击展开疑问：上面这句解释并没有说清楚为什么 $dt/dx=0$</summary>
+  <Aside type="caution" title="疑问">
+    上面这句解释并没有说清楚为什么 $dt/dx=0$
+    
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 $$
 \begin{align}
@@ -512,13 +544,16 @@ $$
 
 但是，薄板的质量增大了一个相对论因子 $\sqrt{1 - \dfrac{v^2}{c^2}}$
 
-<Aside type="danger" title="修正">
-  这里应该是想说质量增大了一个相对论因子$\dfrac{1}{\sqrt{1-\dfrac{v^2}{c^2}}}$
-  
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+<details>
+  <summary class="custom-summary">点击展开修正：上式应取倒数</summary>
+  <Aside type="danger" title="修正">
+    这里应该是想说质量增大了一个相对论因子$\dfrac{1}{\sqrt{1-\dfrac{v^2}{c^2}}}$
+    
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 质量的增大，从几何角度看，应该是空间位移矢量方向与考察的立体角之间的对应变化，所以：
 
@@ -550,9 +585,9 @@ $A_y'$ 和 $A_z'$ 是 $s'$ 系里引力场 $\vec{A'}$ 在 $y'$ 轴和 $z'$ 轴�
 
 $$
 \begin{align}
-A_x' &= - \dfrac{G m' x'}{(r')^3} \nonumber \\
-A_y' &= - \dfrac{G m' y'}{(r')^3} \nonumber \\
-A_z' &= - \dfrac{G m' z'}{(r')^3} \nonumber
+A_x' &= - \dfrac{G\ m'\ x'}{(r')^3} \nonumber \\
+A_y' &= - \dfrac{G\ m'\ y'}{(r')^3} \nonumber \\
+A_z' &= - \dfrac{G\ m'\ z'}{(r')^3} \nonumber
 \end{align}
 $$
 
@@ -618,10 +653,13 @@ $$
 
 注意，式中 $\gamma dx = dx'$ 是从洛伦兹正变换 $x' = \gamma(x - v t)$ 求微分得到的。
 
-<Aside type="caution" title="疑问">
-  和之前一样，这里直接将 $dt$ 那一项丢掉了，但并未说清楚为什么可以这样做。
-  
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+<details>
+  <summary class="custom-summary">点击展开疑问：为什么可以将 $dt$ 那一项丢掉</summary>
+  <Aside type="caution" title="疑问">
+    和之前一样，这里直接将 $dt$ 那一项丢掉了，但并未说清楚为什么可以这样做。
+    
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>

--- a/src/content/docs/zh-cn/main-works/unified-field-theory/section-0.mdx
+++ b/src/content/docs/zh-cn/main-works/unified-field-theory/section-0.mdx
@@ -11,19 +11,41 @@ import VideoPlayer from '~/components/VideoPlayer.astro';
 import Section01 from "~/assets/main-works/unified-field-theory/section-0/1.png"
 
 
+<details open>
+  <summary class="custom-summary">点击收起注解：写在前面</summary>
+  <Aside title="写在前面">
+    本书中所有被包含在这样的块儿中的文字，均来自网站维护者；不包含在这样的块儿中的文字均来自张祥前。
+
+    本网站上《统一场论》的内容为张祥前本人于 2024年10月13日 亲自发送给 [RainDream](mailto:bzsgbq@163.com) 的版本，可以 [点击此处](https://pan.baidu.com/s/1Fn1A4GZaNUJ8GO89LqJkaw?pwd=grti) 下载原文档。**我们的基本理念是完全保留原著内容**，因此如果您发现本网站上内容与原文档存在出入，欢迎通过本注解右下角的邮箱进行反馈。
+
+    为了帮助读者理解，我们会添加一些重要注解，校对公式，修正细节错误，新增动画、配图等。为了和原著内容进行区分，所有注解都会像这段文字这样，被包含在特殊的样式块儿中。另外，**除新增配图之外的所有注解均默认折叠**，以免破坏读者的阅读体验。
+
+    书中会涉及到一些大学本科《高等数学》和《物理学》相关的知识，可以 [点击此处](https://pan.baidu.com/s/14if0AaMRdByVgxAt5ONaoQ?pwd=bv59) 下载相关教材。书中的一些注解会引用到这些教材上的内容。
+
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
+
+<br />
+
 <Image src={Section01} alt="" class="" style="margin:0 auto;" />
 
 统一场论最早是爱因斯坦提出的，他花了40多年时间，希望把电磁场和引力场统一起来，但没有成功。
 
 人类目前发现了自然界有弱力、电磁场力、万有引力、核力4种不同形式的力，其中电场力和磁场力人类已经统一，核力目前人类对此认识很不完善，弱力在主流科学家看来也被统一在电磁场力中。
 
-<Aside title="注解">
-  这里的 "核力" 就是强力, 又称强相互作用, 是作用于强子之间的力，是已知四种基本作用力中最强的，也是作用距离第二短的（大约在10-15 m 范围内）。(来自 [维基百科](https://zh.wikipedia.org/wiki/%E5%BC%BA%E7%9B%B8%E4%BA%92%E4%BD%9C%E7%94%A8))
+<details>
+  <summary class="custom-summary">点击展开注解: 关于“核力”</summary>
+  <Aside title="注解">
+    这里的“核力”就是强力, 又称强相互作用, 是作用于强子之间的力，是已知四种基本作用力中最强的，也是作用距离第二短的（大约在10-15 m 范围内）。(来自 [维基百科](https://zh.wikipedia.org/wiki/%E5%BC%BA%E7%9B%B8%E4%BA%92%E4%BD%9C%E7%94%A8))
 
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 本文认为电场力和磁场力不是同一种力，弱力是电磁场力和核力的合力，不是基本力。本文论述的电场力、磁场力、万有引力、核力的统一，简单的讲，就是把电场力、磁场力、万有引力、核力写在一个数学公式，以及用数学公式写出电场、磁场、万有引力场【简称引力场】、核力场之间的关系。
 

--- a/src/content/docs/zh-cn/main-works/unified-field-theory/section-13.mdx
+++ b/src/content/docs/zh-cn/main-works/unified-field-theory/section-13.mdx
@@ -12,13 +12,16 @@ import VideoPlayer from '~/components/VideoPlayer.astro';
 
 相对论认为时间、位移、电场、磁场、力、质量等很多物理概念是相对的。对于相对运动的不同观测者来测量，可能有不同的数值，这“相对”两个字延伸一下，其是相对于观测者而言。
 
-<Aside title="注解">
-因为上面这些概念，相对于不同观测者有不同数值，所以恰恰说明这些物理量都不是客观存在的，而是观察者描述出来的东西。
+<details>
+  <summary class="custom-summary">点击展开注解：深入理解相对性</summary>
+  <Aside title="注解">
+    因为上面这些物理量，相对于不同观测者有不同数值，所以恰恰说明这些物理量（如时间、质量等）都不是客观存在的，而是观察者描述出来的东西。
 
-<div style="text-align: right;">
-_由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-</div>
-</Aside>
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 由于时间、位移、速度、力、质量、能量······这些物理概念来自于物体【相对于我们观测者】的运动或者物体周围空间本身的运动。
 

--- a/src/content/docs/zh-cn/main-works/unified-field-theory/section-14.mdx
+++ b/src/content/docs/zh-cn/main-works/unified-field-theory/section-14.mdx
@@ -27,13 +27,16 @@ import Section141 from "~/assets/main-works/unified-field-theory/section-14/1.pn
 
 两个右手螺旋式空间【正面对我们观察者都是逆时针旋转】相互碰撞，旋转相互接触地方空间会减少，表现为相互吸引，而左手螺旋空间和右手螺旋空间相遇，会相互排斥。
 
-<Aside title="注解">
-  为什么旋转相互的接触地方空间会减少？这是因为在接触处空间运动方向相反，相互抵消，如下图所示：
+<details>
+  <summary class="custom-summary">点击展开注解: 为什么旋转相互的接触地方空间会减少？</summary>
+  <Aside title="注解">
+    为什么旋转相互的接触地方空间会减少？这是因为在接触处空间运动方向相反，相互抵消，如下图所示：
 
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 <Image src={Section141} alt="" class=""  style="margin:0 auto;"/>
 

--- a/src/content/docs/zh-cn/main-works/unified-field-theory/section-15.mdx
+++ b/src/content/docs/zh-cn/main-works/unified-field-theory/section-15.mdx
@@ -53,19 +53,22 @@ import img_2024_11_14_17_59_04 from "~/assets/main-works/unified-field-theory/se
 
 二维曲面空间中发生的信息，可以保存在一维线性空间中，严格的证明，可以用场论中的斯托克斯定理。
 
-<Aside title="注解">
-  简单来说，
-  “高斯定理”表明了三维体积分可以转化为二维面积分，
-  “斯托克斯定理”表明二维面积分可以转化为一维线积分。
+<details>
+  <summary class="custom-summary">点击展开注解：关于“高斯定理”和“斯托克斯定理”</summary>
+  <Aside title="注解">
+    简单来说，
+    “高斯定理”表明了三维体积分可以转化为二维面积分，
+    “斯托克斯定理”表明二维面积分可以转化为一维线积分。
+      
+    对上述两定理更详细准确的描述，可以参考“同济大学《高等数学》（第七版）”中第十一章的第五节和第六节。
     
-  对上述两定理更详细准确的描述，可以参考“同济大学《高等数学》（第七版）”中第十一章的第五节和第六节。
-  
-  <Image src={img_2024_11_14_17_59_04} alt="" class="" style="margin:0 auto; width:80%;"/>
+    <Image src={img_2024_11_14_17_59_04} alt="" class="" style="margin:0 auto; width:80%;"/>
 
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 我们需要注意：
 

--- a/src/content/docs/zh-cn/main-works/unified-field-theory/section-19.mdx
+++ b/src/content/docs/zh-cn/main-works/unified-field-theory/section-19.mdx
@@ -21,22 +21,27 @@ import img_2024_11_14_20_29_20 from "~/assets/main-works/unified-field-theory/se
 
 下面我们来建立统一场论中的三维圆柱状螺旋时空方程，来替代相对论中四维时空方程。
 
-<Aside title="注解">
-  以下的变量命名不是很规范清晰，但为了尽量不改动原著内容，仍沿用原著的命名方式。
-  
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+<details>
+  <summary class="custom-summary">点击展开注解: 关于本书中变量命名问题的说明</summary>
+  <Aside title="注解">
+    以下的变量命名不是很规范清晰，但为了尽量不改动原著内容，仍沿用原著的命名方式。
+    
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
-<Aside title="新增配图">
-{/* 调整大小为原图50% */}
-  <Image src={img_2024_11_14_19_52_36} alt="" class="" style="margin:0 auto; width:70%;"/>
-  
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+<details open>
+  <summary class="custom-summary">点击收起配图</summary>
+  <Aside title="新增配图">
+    <Image src={img_2024_11_14_19_52_36} alt="" class="" style="margin:0 auto; width:70%;"/>
+    
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 设想在某处空间区域里存在着一个质点 $o$ 点，相对于我们观测者静止，我们以 $o$ 点为原点，建立一个三维笛卡尔直角坐标系 $x,y,z$ 。
 
@@ -55,13 +60,16 @@ $$
 \end{equation}
 $$
 
-<Aside title="注解">
-  "$\vec{r}$ 随着空间位置 $x, y, z$ 和时间 $t$ 变化而变化"这句话容易引发人的困惑, 让人觉得 $\vec{r}$ 是关于 $x, y, z, t$ 这四个变量的函数, 应写成 $\vec{r}=f(x, y, z, t)$; 但是实际上, 统一场论认为时间是观察者周围空间光速运动所给观察者的感觉, 空间本身的位移和时间其实是同一个东西; 所以上面的公式就是想表述出空间位移和时间的对应关系。
-  
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+<details>
+  <summary class="custom-summary">点击展开注解: 关于 $\vec{r}$ 为什么不表示成 $x, y, z, t$ 的四元函数</summary>
+  <Aside title="注解">
+    "$\vec{r}$ 随着空间位置 $x, y, z$ 和时间 $t$ 变化而变化"这句话容易引发人的困惑, 让人觉得 $\vec{r}$ 是关于 $x, y, z, t$ 这四个变量的函数, 应写成 $\vec{r}=f(x, y, z, t)$; 但是实际上, 统一场论认为时间是观察者周围空间光速运动所给观察者的感觉, 空间本身的位移和时间其实是同一个东西; 所以上面的公式就是想表述出空间位移和时间的对应关系。
+    
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 给出了 $\vec{r}(t)$ 和 $(x, y, z)$ 的具体关系，是以上的时空同一化方程：
 
@@ -71,31 +79,37 @@ $$
 \end{equation}
 $$
 
-<Aside type="danger" title="公式修正">
-  这里将原著上述公式中 $x, y, z$ 修正为带有 $\Delta$ 的项。
+<details>
+  <summary class="custom-summary">点击展开公式修正</summary>
+  <Aside type="danger" title="公式修正">
+    这里将原著上述公式中 $x, y, z$ 修正为带有 $\Delta$ 的项。
 
-  修正后公式: (其中 $\Delta x = x - x_0,\ \Delta y = y - y_0,\ \Delta z = z - z_0$)
+    修正后公式: (其中 $\Delta x = x - x_0,\ \Delta y = y - y_0,\ \Delta z = z - z_0$)
 
-  $$
-  \begin{equation}\nonumber
-  \vec{r}(t) = \vec{r_0}+\vec{c}t = (x_0 + \Delta x)\vec{i} + (y_0 + \Delta y)\vec{j} + (z_0 + \Delta z)\vec{k}
-  \end{equation}
-  $$
+    $$
+    \begin{equation}\nonumber
+    \vec{r}(t) = \vec{r_0}+\vec{c}t = (x_0 + \Delta x)\vec{i} + (y_0 + \Delta y)\vec{j} + (z_0 + \Delta z)\vec{k}
+    \end{equation}
+    $$
 
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 这个方程有时候也可以简写为：
 
-<Aside title="注解">
-  这里简写的含义是, 以空间点 $p$ 在初始时刻的位置为原点, 即 $\vec{r_0}=(0, 0, 0)$
-  
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+<details>
+  <summary class="custom-summary">点击展开注解：此处“简写”的含义</summary>
+  <Aside title="注解">
+    这里简写的含义是, 以空间点 $p$ 在初始时刻的位置为原点, 即 $\vec{r_0}=(0, 0, 0)$
+    
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 $$
 \begin{equation}\nonumber
@@ -113,31 +127,37 @@ $$
 
 $r$ 是矢量 $\vec{r}$ 的数量。
 
-<Aside title="新增动画">
-  <VideoPlayer
-    sources={[
-      { src: "/videos/zh-cn/SpaceTimeIsomorphismEquation.mp4", type: "video/mp4" }
-    ]}
-    imageSrc="/gifs/zh-cn/SpaceTimeIsomorphismEquation.gif"
-    alt="Unified Field Theory Model"
-  />
+<details open>
+  <summary class="custom-summary">点击收起动画</summary>
+  <Aside title="新增动画">
+    <VideoPlayer
+      sources={[
+        { src: "/videos/zh-cn/SpaceTimeIsomorphismEquation.mp4", type: "video/mp4" }
+      ]}
+      imageSrc="/gifs/zh-cn/SpaceTimeIsomorphismEquation.gif"
+      alt="Unified Field Theory Model"
+    />
 
-  <div style="text-align: right;">
-    _由 **[uft@obiscr.com](mailto:uft@obiscr.com)** 添加，[在这里报告错误](https://github.com/unified-field-theory-org/animations/issues/new?title=%E5%8F%91%E7%8E%B0%E5%8A%A8%E7%94%BB%E6%B8%B2%E6%9F%93%E9%94%99%E8%AF%AF&labels=animations)_
-  </div>
-</Aside>
+    <div style="text-align: right;">
+      _由 **[uft@obiscr.com](mailto:uft@obiscr.com)** 添加，[在这里报告错误](https://github.com/unified-field-theory-org/animations/issues/new?title=%E5%8F%91%E7%8E%B0%E5%8A%A8%E7%94%BB%E6%B8%B2%E6%9F%93%E9%94%99%E8%AF%AF&labels=animations)_
+    </div>
+  </Aside>
+</details>
 
-<Aside type="caution" title="疑问">
-  如果一个空间点花费时间 $t$ 从 $(x_0,y_0,z_0)$ 运动到 $(x,y,z)$, 并且空间点的运动轨迹为螺旋线, 那么应该是 $(x_0,y_0,z_0)$ 到 $(x,y,z)$ 的弯曲的运动轨迹线的长度等于 $ct$, 而不是 $(x_0,y_0,z_0)$ 到 $(x,y,z)$ 的直线段的长度为 $ct$, 这应该怎么理解呢?
+<details>
+  <summary class="custom-summary">点击展开疑问</summary>
+  <Aside type="caution" title="疑问">
+    如果一个空间点花费时间 $t$ 从 $(x_0,y_0,z_0)$ 运动到 $(x,y,z)$, 并且空间点的运动轨迹为螺旋线, 那么应该是 $(x_0,y_0,z_0)$ 到 $(x,y,z)$ 的弯曲的运动轨迹线的长度等于 $ct$, 而不是 $(x_0,y_0,z_0)$ 到 $(x,y,z)$ 的直线段的长度为 $ct$, 这应该怎么理解呢?
 
-  <Image src={img_2024_11_14_20_17_48} alt="" class="" style="margin:0 auto; width:50%;"/>
+    <Image src={img_2024_11_14_20_17_48} alt="" class="" style="margin:0 auto; width:50%;"/>
 
-  或许这里不能用惯常的 "位移=速度×时间" 来理解空间的运动, 因为统一场论中本身就是用空间运动来定义时间的。
-  
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+    或许这里不能用惯常的 "位移=速度×时间" 来理解空间的运动, 因为统一场论中本身就是用空间运动来定义时间的。
+    
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 以上方程在相对论中也出现过，相对论中被认为是四维时空距离，真实情况是时间的本质就是我们对光速运动的空间的描述。三维空间中任意一维以光速运动，我们就可以认为是时间。
 
@@ -153,15 +173,18 @@ $r$ 是矢量 $\vec{r}$ 的数量。
 
 如果 $p$ 点在 $XOY$ 平面上以原点为圆心，以角速度 $\omega$ 旋转运动，在 $z$ 轴上以匀速度 $h$ 直线运动，$\vec{r}$ 在 $x$、$y$ 平面上投影长度为 $R$，则有:
 
-<Aside title="新增配图">
-  $XOY$ 平面上的投影
+<details open>
+  <summary class="custom-summary">点击收起配图</summary>
+  <Aside title="新增配图">
+    $XOY$ 平面上的投影
 
-  <Image src={img_2024_11_14_20_22_33} alt="" class="" style="margin:0 auto; width:70%;"/>
-  
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+    <Image src={img_2024_11_14_20_22_33} alt="" class="" style="margin:0 auto; width:70%;"/>
+    
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 $$
 \begin{align}
@@ -171,25 +194,27 @@ z =& z_0 + h t \nonumber
 \end{align}
 $$
 
+<details>
+  <summary class="custom-summary">点击展开公式修正</summary>
+  <Aside type="danger" title="公式修正">
+    原著中完整形式的 "三维螺旋时空方程" 是有问题的, 我对它进行了修正
+    修正后公式: (其中 $t'$ 为 $\vec{r_0}=(x_0, y_0, z_0)$ 对应的时刻, $t''$ 为 $\vec{r}=(x, y, z)$ 对应的时刻, $t'' - t' = t$)
 
-<Aside type="danger" title="公式修正">
-  原著中完整形式的 "三维螺旋时空方程" 是有问题的, 我对它进行了修正
-  修正后公式: (其中 $t'$ 为 $\vec{r_0}=(x_0, y_0, z_0)$ 对应的时刻, $t''$ 为 $\vec{r}=(x, y, z)$ 对应的时刻, $t'' - t' = t$)
+    $$
+    \begin{align}
+    x =& x_0 + R(cos(\omega t'') - cos(\omega t')) \nonumber \\
+    y =& y_0 + R(sin(\omega t'') - sin(\omega t')) \nonumber \\
+    z =& z_0 + h t \nonumber
+    \end{align}
+    $$
 
-  $$
-  \begin{align}
-  x =& x_0 + R(cos(\omega t'') - cos(\omega t')) \nonumber \\
-  y =& y_0 + R(sin(\omega t'') - sin(\omega t')) \nonumber \\
-  z =& z_0 + h t \nonumber
-  \end{align}
-  $$
+    可以明显看出, 原著公式的错误在于, 误认为 $cos(A) - cos(B) = cos(A-B)$
 
-  可以明显看出, 原著公式的错误在于, 误认为 $cos(A) - cos(B) = cos(A-B)$
-
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 以上也可以用以下矢量方程表示，
 
@@ -202,23 +227,26 @@ $$
 \end{equation}
 $$
 
-<Aside type="danger" title="公式修正">
-  修正后公式: (其中 $t'$ 为 $\vec{r_0}=(x_0, y_0, z_0)$ 对应的时刻, $t''$ 为 $\vec{r}=(x, y, z)$ 对应的时刻, $t'' - t' = t$)
-  
-  $$
-  \begin{equation} \nonumber
-  \begin{aligned}
-  \vec{r} =& \vec{r_0} + \vec{c}t \\
-  =& \{x_0 + R[cos(\omega t'') - cos(\omega t')]\} \vec{i} + \{y_0 + R[sin(\omega t'') - sin(\omega t')]\} \vec{j} \\
-  & + (z_0+ht)\vec{k}
-  \end{aligned}
-  \end{equation}
-  $$
+<details>
+  <summary class="custom-summary">点击展开公式修正</summary>
+  <Aside type="danger" title="公式修正">
+    修正后公式: (其中 $t'$ 为 $\vec{r_0}=(x_0, y_0, z_0)$ 对应的时刻, $t''$ 为 $\vec{r}=(x, y, z)$ 对应的时刻, $t'' - t' = t$)
+    
+    $$
+    \begin{equation} \nonumber
+    \begin{aligned}
+    \vec{r} =& \vec{r_0} + \vec{c}t \\
+    =& \{x_0 + R[cos(\omega t'') - cos(\omega t')]\} \vec{i} + \{y_0 + R[sin(\omega t'') - sin(\omega t')]\} \vec{j} \\
+    & + (z_0+ht)\vec{k}
+    \end{aligned}
+    \end{equation}
+    $$
 
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 以上可以叫三维螺旋时空方程。
 
@@ -230,15 +258,18 @@ $$
 \end{equation}
 $$
 
-<Aside title="新增配图">
-  上述“简化”的含义为，以 $\vec{r_0}$ 方向为 $x$ 轴方向，并且以旋转圆心为原点，如下图所示：
+<details>
+  <summary class="custom-summary">点击展开注解：此处“简化”的含义</summary>
+  <Aside title="新增配图">
+    上述“简化”的含义为，以 $\vec{r_0}$ 方向为 $x$ 轴方向，并且以旋转圆心为原点，如下图所示：
 
-  <Image src={img_2024_11_14_20_29_20} alt="" class="" style="margin:0 auto; width:60%;"/>
+    <Image src={img_2024_11_14_20_29_20} alt="" class="" style="margin:0 auto; width:60%;"/>
 
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 统一场论认为，宇宙的一切奥妙都是以上方程决定的，大到银河系、星球，小到电子、质子、中子的运动，以及物体为什么有质量、为什么有电荷，一直到人的思维等等······，都与这个方程有关。
 
@@ -257,13 +288,16 @@ $$
 
 上式 $\mathbf{X}$ , $\mathbf{Y}$ 是旋转量，如果 $\mathbf{X} \times \mathbf{Y} = \mathbf{Z}$ 表示右手螺旋关系，则 $\mathbf{Y} \times \mathbf{X} = - \mathbf{Z}$ 则表示左手螺旋关系。
 
-<Aside type="caution" title="疑问">
-  这里应该都是表示右手螺旋关系吧？
-  
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+<details>
+  <summary class="custom-summary">点击展开疑问：应该都是表示右手螺旋关系吧？</summary>
+  <Aside type="caution" title="疑问">
+    这里应该都是表示右手螺旋关系吧？
+    
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 式 $\mathbf{X} \times \mathbf{Y} = \mathbf{Z}$ 和 $\mathbf{Y} \times \mathbf{X} = - \mathbf{Z}$ 反映了空间的旋转运动和直线运动之间的联系。
 

--- a/src/content/docs/zh-cn/main-works/unified-field-theory/section-20.mdx
+++ b/src/content/docs/zh-cn/main-works/unified-field-theory/section-20.mdx
@@ -35,13 +35,16 @@ $$
 
 就是时空同一化方程。
 
-<Aside title="注解">
-  上述方程中的 $\vec{r}$ 为空间位矢，相当于将时间和空间写到了一个等式里，因此叫做时空同一化方程。其实这个方程其实就是描述了空间运动，并用它来定义了时间。
-  
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+<details>
+  <summary class="custom-summary">点击展开注解：关于上述方程为什么叫“时空同一化方程”的进一步说明</summary>
+  <Aside title="注解">
+    上述方程中的 $\vec{r}$ 为空间位矢，相当于将时间和空间写到了一个等式里，因此叫做时空同一化方程。其实这个方程其实就是描述了空间运动，并用它来定义了时间。
+    
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 原子中的电子生活在小空间范围内，运动速度极快，运动周期极短。而太阳系内，行星在大范围空间里运动，速度小，周期长，这一切的背后都是时空同一性的原因。
 

--- a/src/content/docs/zh-cn/main-works/unified-field-theory/section-21.mdx
+++ b/src/content/docs/zh-cn/main-works/unified-field-theory/section-21.mdx
@@ -14,14 +14,17 @@ import Section213 from "~/assets/main-works/unified-field-theory/section-21/3.pn
 
 ## 对洛伦兹变换中光速不变的解释
 
-<Aside title="注解">
-  这一部分其实在推导 $\vec{v}$ (光源运动速度) 与 $\vec{c}$ (矢量光速) 方向相同时的洛伦兹变换公式，并且推导方式就是目前物理学界常用的方式，并不是统一场论提出的。但是统一场论对其中的光速不变进行了更加本质和深刻的解释。
-  
-  另外，下面的变量命名也存在各种细节问题，比如：既把 $x$ 作为一个坐标值, 又把它作为一个坐标轴的名称; 点 $p$ 在正文中用的小写字母，在图片中却用的大写字母；坐标系 $s$ 在正文中用的小写字母，在图片中却用的大写字母；等等。但由于不影响理解, 先不进行校正。
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+<details>
+  <summary class="custom-summary">点击展开注解：本节导读</summary>
+  <Aside title="注解">
+    这一部分其实在推导 $\vec{v}$ (光源运动速度) 与 $\vec{c}$ (矢量光速) 方向相同时的洛伦兹变换公式，并且推导方式就是目前物理学界常用的方式，并不是统一场论提出的。但是统一场论对其中的光速不变进行了更加本质和深刻的解释。
+    
+    另外，下面的变量命名也存在各种细节问题，比如：既把 $x$ 作为一个坐标值, 又把它作为一个坐标轴的名称; 点 $p$ 在正文中用的小写字母，在图片中却用的大写字母；坐标系 $s$ 在正文中用的小写字母，在图片中却用的大写字母；等等。但由于不影响理解, 先不进行校正。
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 设有两个直角惯性坐标系 $s$ 系和 $s'$ 系，任意一事件发生的地点【我们称为考察点 $p$】、时间，在 $s$ 系、$s'$ 系中的时空坐标分别用 $(x, y, z, t)$ 和 $(x', y', z', t')$ 来表示。
 
@@ -92,13 +95,16 @@ $$
 
 由于 $s$ 系相对于 $s'$ 系是匀速直线运动，因而我们应该合理的认为 $x'$ 和 $(x-vt)$ ，$x$ 和 $(x'+vt')$ 之间的关系应该是线性的，满足于简单的正比关系。
 
-<Aside type="caution" title="疑问">
-  上面这句描述看起来很想当然，不严谨，仍需进一步的解释。
-  
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+<details>
+  <summary class="custom-summary">点击展开疑问：关于上述论述的严谨性</summary>
+  <Aside type="caution" title="疑问">
+    上面这句描述看起来很想当然，不严谨，仍需进一步的解释。
+    
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 相对论的相对性原理认为：物理定律在所有的惯性参考系中都是相同或者平权的，不同惯性系的物理方程形式应该是相同的。
 
@@ -239,13 +245,16 @@ $$
 \end{equation}
 $$
 
-<Aside title="注解">
-  上面 "量纲是速率" 的表述不太准确. 明白他想表达的意思即可.
-  
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+<details>
+  <summary class="custom-summary">点击展开注解：关于上述“量纲是速率”的表述</summary>
+  <Aside title="注解">
+    上面“量纲是速率”的表述不太准确. 明白他想表达的意思即可。
+    
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 所以，以上说明了一定会有一个与时间密切相关的特殊速率【我们用 $c$ 来表示】，在相互运动的两个观测者看来，$c$ 的值是相等的。
 
@@ -310,14 +319,16 @@ $$
 
 ## 在空间点运动方向与速度 v 垂直的情况下光速不变的解释
 
-<Aside title="注解">
-  这一部分其实在推导 $\vec{v}$ (光源运动速度) 与 $\vec{c}$ (矢量光速) 方向垂直时的洛伦兹变换公式，并且推导方式就是目前物理学界常用的方式，并不是统一场论提出的。
-  
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
-
+<details>
+  <summary class="custom-summary">点击展开注解：本节导读</summary>
+  <Aside title="注解">
+    这一部分其实在推导 $\vec{v}$ (光源运动速度) 与 $\vec{c}$ (矢量光速) 方向垂直时的洛伦兹变换公式，并且推导方式就是目前物理学界常用的方式，并不是统一场论提出的。
+    
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 可能有人认为光线可以向任意方向跑啊，那空间岂不是也向任意方向跑吗？描述任何运动需有参照物，空间的运动又是参照谁呢？
 
@@ -343,13 +354,16 @@ $$
 
 空间点 $p$ 在零时刻出发运动到 $p$ 点这个事情，在 $s$ 系的观察者看来，$p$ 点在时间 $t$ 内走了 $op$ 这么远的路程。
 
-<Aside title="注解">
-  上面又同时用 $p$ 这个字母表示 "空间点" 和 "空间点在上述运动过程中的结束位置" 了，明白意思就好，这里不影响理解，所以尽量保留原著内容，不进行校正。
-  
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+<details>
+  <summary class="custom-summary">点击展开注解：关于一个字母表示多种含义的问题</summary>
+  <Aside title="注解">
+    上面又同时用 $p$ 这个字母表示 "空间点" 和 "空间点在上述运动过程中的结束位置" 了，明白意思就好，这里不影响理解，所以尽量保留原著内容，不进行校正。
+    
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 $op$ 的路程虽然比 $o'p$ 远，但是，所~~有~~用的时间 $t$ 应该比时间 $t'$ 要长。
 
@@ -613,13 +627,16 @@ c'_z &= \dfrac{c_z\sqrt{1-\dfrac{v^2}{c^2}}}{1-\dfrac{c_x v}{c^2}} \nonumber
 \end{align}
 $$
 
-<Aside title="注解">
-  上述公式是基于目前物理界常用的“完整形式的相对论速度变换公式”，又可称“完整形式的洛伦兹速度变换公式”得到的。具体公式可参考 [此链接](https://www.cnblogs.com/howardzhangdqs/p/rtor.html#612-%E5%AE%8C%E6%95%B4%E7%9A%84%E6%B4%9B%E4%BC%A6%E5%85%B9%E9%80%9F%E5%BA%A6%E5%8F%98%E6%8D%A2%E5%85%AC%E5%BC%8F)。具体推导过程可参考 [此链接](https://query.libretexts.org/%E7%AE%80%E4%BD%93%E4%B8%AD%E6%96%87/%E5%A4%A7%E5%AD%A6%E7%89%A9%E7%90%86%E5%AD%A6_III-%E5%85%89%E5%AD%A6%E4%B8%8E%E7%8E%B0%E4%BB%A3%E7%89%A9%E7%90%86%E5%AD%A6_(OpenSTAX)/05%3A_%E7%9B%B8%E5%AF%B9%E8%AE%BA/5.07%3A_%E7%9B%B8%E5%AF%B9%E8%AE%BA%E9%80%9F%E5%BA%A6%E5%8F%98%E6%8D%A2)（该链接推导的是逆变换，本书这里用的公式是正变换, 它们的推导思想是相同的）。
-  
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+<details>
+  <summary class="custom-summary">点击展开注解：关于上述公式的推导</summary>
+  <Aside title="注解">
+    上述公式是基于目前物理界常用的“完整形式的相对论速度变换公式”，又可称“完整形式的洛伦兹速度变换公式”得到的。具体公式可参考 [此链接](https://www.cnblogs.com/howardzhangdqs/p/rtor.html#612-%E5%AE%8C%E6%95%B4%E7%9A%84%E6%B4%9B%E4%BC%A6%E5%85%B9%E9%80%9F%E5%BA%A6%E5%8F%98%E6%8D%A2%E5%85%AC%E5%BC%8F)。具体推导过程可参考 [此链接](https://query.libretexts.org/%E7%AE%80%E4%BD%93%E4%B8%AD%E6%96%87/%E5%A4%A7%E5%AD%A6%E7%89%A9%E7%90%86%E5%AD%A6_III-%E5%85%89%E5%AD%A6%E4%B8%8E%E7%8E%B0%E4%BB%A3%E7%89%A9%E7%90%86%E5%AD%A6_(OpenSTAX)/05%3A_%E7%9B%B8%E5%AF%B9%E8%AE%BA/5.07%3A_%E7%9B%B8%E5%AF%B9%E8%AE%BA%E9%80%9F%E5%BA%A6%E5%8F%98%E6%8D%A2)（该链接推导的是逆变换，本书这里用的公式是正变换, 它们的推导思想是相同的）。
+    
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 由以上可以导出：
 

--- a/src/content/docs/zh-cn/main-works/unified-field-theory/section-22.mdx
+++ b/src/content/docs/zh-cn/main-works/unified-field-theory/section-22.mdx
@@ -89,12 +89,15 @@ import img_2024_11_15_10_37_28 from "~/assets/main-works/unified-field-theory/se
 
 场的本质是以圆柱状螺旋式运动的空间，圆柱状螺旋式运动是旋转运动和旋转平面垂直方向直线运动的合成，而散度描述了空间的直线运动部分，旋度描述了空间的旋转运动部分。
 
-<Aside title="注解">
-  上述 "高斯定理", "斯托克斯定理", "散度", "旋度" 等, 可以参考“同济大学《高等数学》（第七版）下册”中第十一章的第五节和第六节进行更深入的了解。
+<details>
+  <summary class="custom-summary">点击展开注解：关于上述“高斯定理”、“斯托克斯定理”、“散度”、“旋度”等概念</summary>
+  <Aside title="注解">
+    上述“高斯定理”、“斯托克斯定理”、“散度”、“旋度”等概念，可以参考“同济大学《高等数学》（第七版）下册”中第十一章的第五节和第六节进行更深入的了解。
 
-  <Image src={img_2024_11_15_10_37_28} alt="" class="" style="margin:0 auto; width:80%;"/>
-  
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+    <Image src={img_2024_11_15_10_37_28} alt="" class="" style="margin:0 auto; width:80%;"/>
+    
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>

--- a/src/content/docs/zh-cn/main-works/unified-field-theory/section-23.mdx
+++ b/src/content/docs/zh-cn/main-works/unified-field-theory/section-23.mdx
@@ -19,13 +19,16 @@ import img_2024_11_15_10_59_13 from "~/assets/main-works/unified-field-theory/se
 
 $o$ 点在周围产生的引力场 $\vec{A}$ ，表示了穿过包围 $o$ 点的高斯球面 $s$ 上，以光速发散运动的空间位移的条数。
 
-<Aside title="注解">
-  "高斯球面" (Gaussian surface) 是在矢量场分析中的一个重要概念，它是一个假想的封闭曲面。在这里，具体是指围绕质点 $o$ 的一个球形封闭曲面，可以是任意半径。这个球面用于计算通过它的空间位移通量。
-  
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+<details>
+  <summary class="custom-summary">点击展开注解：什么是“高斯球面”？</summary>
+  <Aside title="注解">
+    “高斯球面” (Gaussian surface) 是在矢量场分析中的一个重要概念，它是一个假想的封闭曲面。在这里，具体是指围绕质点 $o$ 的一个球形封闭曲面，可以是任意半径。这个球面用于计算通过它的空间位移通量。
+    
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 
 ## 引力场的定义方程
@@ -40,15 +43,18 @@ $$
 \end{equation}
 $$
 
-<Aside title="注解">
-  此处公式容易引发误解，因为它将 $\vec{r}$ 写成一个关于 $x, y, z, t$ 的四元函数，将时间 $t$ 看作了第四个维度，让人感觉和统一场论的时空同一性背道而驰，反而是降维到了相对论的四维时空观。更符合统一场论基本原理的公式，可以参考本书“十九、螺旋时空波动方程”中如下图所示部分内容。但这里无需纠结这一问题，因为不影响本章内容的理解。
+<details>
+  <summary class="custom-summary">点击展开注解：关于此处将 $\vec{r}$ 写成了一个关于 $x, y, z, t$ 的四元函数</summary>
+  <Aside title="注解">
+    此处公式容易引发误解，因为它将 $\vec{r}$ 写成一个关于 $x, y, z, t$ 的四元函数，将时间 $t$ 看作了第四个维度，让人感觉和统一场论的时空同一性背道而驰，反而是降维到了相对论的四维时空观。更符合统一场论基本原理的公式，可以参考本书“十九、螺旋时空波动方程”中如下图所示部分内容。但这里无需纠结这一问题，因为不影响本章内容的理解。
 
-  <Image src={img_2024_11_15_10_53_02} alt="" class="" style="margin:0 auto; width:80%;"/>
-  
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+    <Image src={img_2024_11_15_10_53_02} alt="" class="" style="margin:0 auto; width:80%;"/>
+    
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 注意，$p$ 点在空间中走过的轨迹是圆柱状螺旋式，我们也可以认为是矢径 $\vec{r}$ 的一个端点 $o$ 不动，另一个端点 $p$ 运动变化，使得 $\vec{r}$ 在空间中划过一条圆柱状螺旋式轨迹。
 
@@ -66,15 +72,18 @@ A = 常数乘以 \dfrac{\Delta{n}}{\Delta{S}}
 \end{equation}
 $$
 
-<Aside title="注解">
-  这里实际上是给出了“引力场强度大小”和“空间位移密度”之间的关系：“引力场强度”的大小，就等于“空间位移密度”。这与目前大学物理教材中, 给出的“电场强度”就等于“电场线密度”，是类似的：(以下内容截取自“马文蔚《物理学》（第六版）上册” p172)
-  
-  <Image src={img_2024_11_15_10_59_13} alt="" class="" style="margin:0 auto; width:80%;"/>
+<details>
+  <summary class="custom-summary">点击展开注解：与“电场强度”的类比</summary>
+  <Aside title="注解">
+    这里实际上是给出了“引力场强度大小”和“空间位移密度”之间的关系：“引力场强度”的大小，就等于“空间位移密度”。这与目前大学物理教材中, 给出的“电场强度”就等于“电场线密度”，是类似的：(以下内容截取自“马文蔚《物理学》（第六版）上册” p172)
+    
+    <Image src={img_2024_11_15_10_59_13} alt="" class="" style="margin:0 auto; width:80%;"/>
 
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 上式给出的引力场定义简单明了，但过于粗糙，不能把引力场矢量性质表现出来，也没有把以矢量光速运动的空间位移 $\vec{r}$ 带进式子中去。
 
@@ -105,23 +114,26 @@ $$
 \end{equation}
 $$
 
-<Aside type="caution" title="疑问">
-  我对上面这段论述有极大的疑惑：“因为只有 $\Delta{n}=1$ 的情况下公式才具有物理意义，所以 $\Delta{n}$ 就直接等于1” 这种说法肯定是有问题的；至少是表述得很不清晰和不严谨的。
+<details>
+  <summary class="custom-summary">点击展开疑问</summary>
+  <Aside type="caution" title="疑问">
+    我对上面这段论述有极大的疑惑：“因为只有 $\Delta{n}=1$ 的情况下公式才具有物理意义，所以 $\Delta{n}$ 就直接等于1” 这种说法肯定是有问题的；至少是表述得很不清晰和不严谨的。
 
-  按照我的理解，应该写为：
+    按照我的理解，应该写为：
 
-  $$
-  \begin{equation}\nonumber
-  \vec{A} = - \dfrac{G\ k\ \Delta{n}\ \vec{r}}{\Delta{S}\ r} = - \dfrac{G\ k\ \vec{r}}{\frac{\Delta{S}}{\Delta{n}}\ r}
-  \end{equation}
-  $$
+    $$
+    \begin{equation}\nonumber
+    \vec{A} = - \dfrac{G\ k\ \Delta{n}\ \vec{r}}{\Delta{S}\ r} = - \dfrac{G\ k\ \vec{r}}{\frac{\Delta{S}}{\Delta{n}}\ r}
+    \end{equation}
+    $$
 
-  我认为原著公式中第三个式子 ($- \frac{G\ k\ \vec{r}}{\Delta{S}\ r}$) 中的 $\Delta{S}$，其实表达的是 "单位条数对应的面积"，和第二个式子 ($- \frac{G\ k\ \Delta{n}\ \vec{r}}{\Delta{S}\ r}$) 中的 $\Delta{S}$ 其实是不同的，但作者用了同一个字母表达它们。而且很乱的一点是，这里明明舍弃了 $\Delta{n}$，但是下面依然频繁出现 $\Delta{n}$。
-  
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+    我认为原著公式中第三个式子 ($- \frac{G\ k\ \vec{r}}{\Delta{S}\ r}$) 中的 $\Delta{S}$，其实表达的是 "单位条数对应的面积"，和第二个式子 ($- \frac{G\ k\ \Delta{n}\ \vec{r}}{\Delta{S}\ r}$) 中的 $\Delta{S}$ 其实是不同的，但作者用了同一个字母表达它们。而且很乱的一点是，这里明明舍弃了 $\Delta{n}$，但是下面依然频繁出现 $\Delta{n}$。
+    
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 上式中为什么用 $\vec{r}$ 的单位矢量 $\dfrac{\vec{r}}{c}$，而不是直接用矢量 $\vec{r}$ ？
 
@@ -135,13 +147,16 @@ $$
 \end{equation}
 $$
 
-<Aside type="danger" title="公式修正">
-  上述公式最后一个式子似乎少乘了一个 $cos \theta$；即最后一个式子应为: $-G\ k\ \Delta n\ cos \theta$
-  
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+<details>
+  <summary class="custom-summary">点击展开公式修正：最后一个式子似乎少乘了一个 $cos \theta$</summary>
+  <Aside type="danger" title="公式修正">
+    上述公式最后一个式子似乎少乘了一个 $cos \theta$；即最后一个式子应为: $-G\ k\ \Delta n\ cos \theta$
+    
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 上式中 $A$ 是引力场 $\vec{A}$ 的数量。
 
@@ -262,13 +277,16 @@ m = \dfrac{k}{\Omega}
 \end{equation}
 $$
 
-<Aside title="注解">
-  注意上式中 $\Omega$ 的含义也会发生变化，变成“单位空间位移对应的立体角”了。原著中经常有类似的地方，用同一个字母表达多个含义，明白其意思就好。
-  
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+<details>
+  <summary class="custom-summary">点击展开注解：关于上式中 $\Omega$ 含义的说明</summary>
+  <Aside title="注解">
+    注意上式中 $\Omega$ 的含义也会发生变化，变成“单位空间位移对应的立体角”了。原著中经常有类似的地方，用同一个字母表达多个含义，明白其意思就好。
+    
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 我们一旦知道了质量的本质，就可以对牛顿力学中的引力场方程 $\vec{A} = -\dfrac{G\ m\ \vec{r}}{r^3}$ 做出解释。
 
@@ -296,18 +314,20 @@ $$
 \end{equation}
 $$
 
-
-<Aside title="注解">
-  这里的 $\vec{\nabla}$ 叫做向量微分算子。
-  
-  对于一般的向量场: $\vec{A}(x, y, z) = P(x, y, z)\vec{i} + Q(x, y, z)\vec{j} + R(x, y, z)\vec{k}$, $(\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z})\vec{i} + (\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x})\vec{j} + (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\vec{k}$ 叫做向量场 $\vec{A}$ 的旋度, 记作 $\overrightarrow{\textup{rot}}\ \vec{A}$. 并且有 $\overrightarrow{\textup{rot}} \vec{A} = \vec{\nabla} \times \vec{A}$ 
-  
-  (摘自“同济大学《高等数学》（第七版）下册” p246)
-  
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+<details>
+  <summary class="custom-summary">点击展开注解：关于“旋度”</summary>
+  <Aside title="注解">
+    这里的 $\vec{\nabla}$ 叫做向量微分算子。
+    
+    对于一般的向量场: $\vec{A}(x, y, z) = P(x, y, z)\vec{i} + Q(x, y, z)\vec{j} + R(x, y, z)\vec{k}$, $(\frac{\partial R}{\partial y} - \frac{\partial Q}{\partial z})\vec{i} + (\frac{\partial P}{\partial z} - \frac{\partial R}{\partial x})\vec{j} + (\frac{\partial Q}{\partial x} - \frac{\partial P}{\partial y})\vec{k}$ 叫做向量场 $\vec{A}$ 的旋度, 记作 $\overrightarrow{\textup{rot}}\ \vec{A}$. 并且有 $\overrightarrow{\textup{rot}} \vec{A} = \vec{\nabla} \times \vec{A}$ 
+    
+    (摘自“同济大学《高等数学》（第七版）下册” p246)
+    
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 对静止引力场
 
@@ -325,13 +345,16 @@ $$
 \end{equation}
 $$
 
-<Aside title="注解">
-  对于一般的向量场：$\vec{A}(x, y, z) = P(x, y, z)\vec{i} + Q(x, y, z)\vec{j} + R(x, y, z)\vec{k}$，$\frac{\partial P}{\partial x} + \frac{\partial Q}{\partial y} + \frac{\partial R}{\partial z}$ 叫做向量场 $\vec{A}$ 的散度，记作 $\textup{div}\ \vec{A}$。并且有 $\textup{div}\ \vec{A} = \vec{\nabla} \cdot \vec{A} = \frac{\partial P}{\partial x} + \frac{\partial Q}{\partial y} + \frac{\partial R}{\partial z}$ (摘自“同济大学《高等数学》（第七版）下册” p238)
-  
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+<details>
+  <summary class="custom-summary">点击展开注解：关于“散度”</summary>
+  <Aside title="注解">
+    对于一般的向量场：$\vec{A}(x, y, z) = P(x, y, z)\vec{i} + Q(x, y, z)\vec{j} + R(x, y, z)\vec{k}$，$\frac{\partial P}{\partial x} + \frac{\partial Q}{\partial y} + \frac{\partial R}{\partial z}$ 叫做向量场 $\vec{A}$ 的散度，记作 $\textup{div}\ \vec{A}$。并且有 $\textup{div}\ \vec{A} = \vec{\nabla} \cdot \vec{A} = \frac{\partial P}{\partial x} + \frac{\partial Q}{\partial y} + \frac{\partial R}{\partial z}$ (摘自“同济大学《高等数学》（第七版）下册” p238)
+    
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 但在 $r$ 趋近于零【也可以说空间点 $p$ 无限趋近于 $o$ 点】，且 $o$ 点可以看成一个无限小的球体的情况下，式子出现了 $\dfrac{0}{0}$ 的情况，利用狄拉克 $\delta$ 函数，可以得到：
 
@@ -345,13 +368,16 @@ $G$ 是万有引力常数，$u = \dfrac{m}{\Delta x \Delta y \Delta z}$ 是物�
 
 统一场论给出的引力场定义方程的旋度和散度，和牛顿力学给出的引力场的散度、旋度是一致的。
 
-<Aside title="注解">
-  肯定是一致的。因为统一场论给出的引力场定义方程，相比于牛顿力学，只是进一步将质量 $m$ 展开为 $\dfrac{k\ \Delta n}{\Omega}$，而上述推导都假设 $m$ 不变，将其视作常数。
-  
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+<details>
+  <summary class="custom-summary">点击展开注解：为什么是一致的？</summary>
+  <Aside title="注解">
+    肯定是一致的。因为统一场论给出的引力场定义方程，相比于牛顿力学，只是进一步将质量 $m$ 展开为 $\dfrac{k\ \Delta n}{\Omega}$，而上述推导都假设 $m$ 不变，将其视作常数。
+    
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 
 ## 从质量定义方程导出相对论质速关系
@@ -406,13 +432,16 @@ d\Omega = dV
 \end{equation}
 $$
 
-<Aside type="caution" title="疑问">
-  由于 $\Delta V = \dfrac{1}{3}\Delta S\ r$，所以上面的两个公式是否应该分别修正成 $d\Omega = \dfrac{3\ dV}{r^3}$ 和 $d\Omega = 3\ dV$ ？
-  
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+<details>
+  <summary class="custom-summary">点击展开疑问：上式是否应该写为 $d\Omega = 3\ dV$ ？</summary>
+  <Aside type="caution" title="疑问">
+    由于 $\Delta V = \dfrac{1}{3}\Delta S\ r$，所以上面的两个公式是否应该分别修正成 $d\Omega = \dfrac{3\ dV}{r^3}$ 和 $d\Omega = 3\ dV$ ？
+    
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 有了以上的准备知识，我们来考虑以上的 $o$ 点在 $s'$ 系里，静止时候质量
 
@@ -457,13 +486,16 @@ $$
 
 我们只有把 $s$ 系里的时间 $t$ 取一个固定的时刻，$x$ 和 $x'$ 相互比较才有意义，所以，$dt/dx=0$，得出微分式：
 
-<Aside type="caution" title="疑问">
-  上面这句解释并没有说清楚为什么 $dt/dx=0$
-  
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+<details>
+  <summary class="custom-summary">点击展开疑问：上面这句解释并没有说清楚为什么 $dt/dx=0$</summary>
+  <Aside type="caution" title="疑问">
+    上面这句解释并没有说清楚为什么 $dt/dx=0$
+    
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 $$
 \begin{align}
@@ -509,13 +541,16 @@ $$
 
 但是，薄板的质量增大了一个相对论因子 $\sqrt{1 - \dfrac{v^2}{c^2}}$
 
-<Aside type="danger" title="修正">
-  这里应该是想说质量增大了一个相对论因子$\dfrac{1}{\sqrt{1-\dfrac{v^2}{c^2}}}$
-  
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+<details>
+  <summary class="custom-summary">点击展开修正：上式应取倒数</summary>
+  <Aside type="danger" title="修正">
+    这里应该是想说质量增大了一个相对论因子$\dfrac{1}{\sqrt{1-\dfrac{v^2}{c^2}}}$
+    
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>
 
 质量的增大，从几何角度看，应该是空间位移矢量方向与考察的立体角之间的对应变化，所以：
 
@@ -615,10 +650,13 @@ $$
 
 注意，式中 $\gamma dx = dx'$ 是从洛伦兹正变换 $x' = \gamma(x - v t)$ 求微分得到的。
 
-<Aside type="caution" title="疑问">
-  和之前一样，这里直接将 $dt$ 那一项丢掉了，但并未说清楚为什么可以这样做。
-  
-  <div style="text-align: right;">
-    _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
-  </div>
-</Aside>
+<details>
+  <summary class="custom-summary">点击展开疑问：为什么可以将 $dt$ 那一项丢掉</summary>
+  <Aside type="caution" title="疑问">
+    和之前一样，这里直接将 $dt$ 那一项丢掉了，但并未说清楚为什么可以这样做。
+    
+    <div style="text-align: right;">
+      _由 **[RainDream](mailto:bzsgbq@163.com)** 添加_
+    </div>
+  </Aside>
+</details>

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -29,3 +29,10 @@
 .katex-display>.katex>.katex-html>.tag {
 	right: 2px !important;
 }
+
+.custom-summary {
+    font-size: 0.8em !important;          /* 字体大小 */
+    color: #999999 !important;          /* 字体颜色 */
+    font-style: italic !important;        /* 倾斜 */
+    cursor: pointer !important;           /* 鼠标指针样式 */
+}

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -26,13 +26,13 @@
 	overflow-y: hidden;
 }
 
-.katex-display>.katex>.katex-html>.tag {
+.katex-display > .katex > .katex-html > .tag {
 	right: 2px !important;
 }
 
 .custom-summary {
-    font-size: 0.8em !important;          /* 字体大小 */
-    color: #999999 !important;          /* 字体颜色 */
-    font-style: italic !important;        /* 倾斜 */
-    cursor: pointer !important;           /* 鼠标指针样式 */
+	font-size: 0.8em !important; /* 字体大小 */
+	color: #999999 !important; /* 字体颜色 */
+	font-style: italic !important; /* 倾斜 */
+	cursor: pointer !important; /* 鼠标指针样式 */
 }


### PR DESCRIPTION
本 PR 将我所添加的注解都默认折叠起来 (新增配图/动画除外). 不然页面上全是我花花绿绿的注解, 影响阅读体验.

之前:
<img width="1210" alt="image" src="https://github.com/user-attachments/assets/9fc8da2c-7731-4c98-abea-a11c0e6da073">

现在:
<img width="1221" alt="image" src="https://github.com/user-attachments/assets/aeb46299-130b-4dfb-9fa7-5ee652e00a1c">
